### PR TITLE
Reduce CPU count to 1

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ vm_ip_address = "192.168.60.25"
 vm_naked_hostname = "lucee.dev"
 vm_name = "Lucee-CFML"
 vm_max_memory = 1024
-vm_num_cpus = 2
+vm_num_cpus = 1
 vm_max_host_cpu_cap = "100"
 
 # synced folder configuration


### PR DESCRIPTION
My recent experience is that reducing the Virtual CPU setting speeds up performance considerably. This appears to be supported by other articles out there on the interwebs. I'm proposing it as a change to your template since I have used it as a reference point a lot. Test the change and see if you see a performance improvement too.

For more information see:
https://ruin.io/2014/benchmarking-virtualbox-multiple-core-performance/
https://github.com/roots/trellis/issues/410
