### PR TITLE
add vagrant to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The first time you clone the repo and bring the box up, it may take several minu
 
 ```
 $ git clone git@github.com:Ortus-Solutions/vagrant-centos-lucee.git
-$ cd vagrant-centos-lucee && vagrant up
+$ cd vagrant-centos-lucee/vagrant && vagrant up
 ```
 
 Once the Vagrant box finishes and is ready, you should see something like this in your terminal:


### PR DESCRIPTION
Added vagrant to the `cd` path because the command 'as is' will not work since you need to be in the vagrant folder
